### PR TITLE
fix: removes 'undefined' class appearing in dom

### DIFF
--- a/src/react/factory.tsx
+++ b/src/react/factory.tsx
@@ -106,7 +106,7 @@ export default ( Tag: `img` | `video`, withAlt?: boolean ):
             const { props } = this;
             const alt = withAlt && parseAlt( props.alt );
             const bot = parseBot( props.bot );
-            const className = parseClassName( props.className );
+            const className = parseClassName( props.className ) || "";
             const focus = parseFocus( props.focus );
             const mode = parseMode( props.mode );
             const placeholder = parsePlaceholder( props.placeholder );


### PR DESCRIPTION
When there are no additional classes, this ends up as in the dom, eg:

```html
<div class="twic-i  undefined ">
  ...
</div>
```


![Google Chrome - components  atoms   TwicPics - appearance full ⋅ Storybook 2022-05-05 at 14 50 24](https://user-images.githubusercontent.com/39598117/166926547-9d385c0a-5192-49d7-a20e-df24fc1cfa90.png)
