### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/nuxt3/plugin.js
+++ b/src/nuxt3/plugin.js
@@ -1,5 +1,5 @@
 import TwicPics from "@twicpics/components/vue3";
-import { defineNuxtPlugin, useRuntimeConfig } from '#app';
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports';
 
 export default defineNuxtPlugin( nuxtApp => {
     const runtimeConfig = useRuntimeConfig();


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.